### PR TITLE
Add 2D and 3D UMAP input for single-cell profiles

### DIFF
--- a/1.EDA/notebooks/0.generate_umap.ipynb
+++ b/1.EDA/notebooks/0.generate_umap.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 19,
    "id": "62efb8fa",
    "metadata": {},
    "outputs": [],
@@ -35,83 +35,82 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 17,
    "id": "091582c7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using projection method: max_projection\n",
+      "Output directory: /Users/kaylorhuang/Documents/GitHub_Repos/Kaylor---NF1_organoid_profile_analysis/1.EDA/results/umap/2D/max_projection\n"
+     ]
+    }
+   ],
    "source": [
-    "# paths to data\n",
+    "# Configuration: Choose dimension and projection method\n",
+    "\n",
+    "DIMENSION = \"2D\"  # (2D or 3D)\n",
+    "PROJECTION_METHOD = \"max_projection\"  # Only used for 2D. Options: \"max_intensity\", \"middle_slice\"\n",
+    "\n",
+    "#Data paths\n",
+    "if DIMENSION == \"3D\":\n",
+    "    input_base = f\"{profile_base_dir}/data/3D_all_patient_profiles\"\n",
+    "    output_base = f\"{root_dir}/1.EDA/results/umap/3D\"\n",
+    "elif DIMENSION == \"2D\":\n",
+    "    input_base = f\"{profile_base_dir}/data/2D_all_patient_profiles/{PROJECTION_METHOD}\"\n",
+    "    output_base = f\"{root_dir}/1.EDA/results/umap/2D/{PROJECTION_METHOD}\"\n",
+    "else:\n",
+    "    raise ValueError(f\"DIMENSION must be '2D' or '3D', got '{DIMENSION}'\")\n",
+    "\n",
+    "# Data dictionary (only for single cell profiles for now)\n",
     "data_dict = {\n",
     "    \"sc\": {\n",
     "        \"input\": pathlib.Path(\n",
-    "            f\"{profile_base_dir}/data/all_patient_profiles/sc_profiles.parquet\"\n",
+    "            f\"{input_base}/sc_profiles.parquet\"\n",
     "        ).resolve(strict=True),\n",
-    "        \"output\": pathlib.Path(f\"{root_dir}/5.EDA/results/sc_umap.parquet\").resolve(),\n",
+    "        \"output\": pathlib.Path(\n",
+    "            f\"{output_base}/sc_umap.parquet\"\n",
+    "        ).resolve(),\n",
     "    },\n",
     "    \"sc_fs\": {\n",
     "        \"input\": pathlib.Path(\n",
-    "            f\"{profile_base_dir}/data/all_patient_profiles/sc_fs_profiles.parquet\"\n",
+    "            f\"{input_base}/sc_fs_profiles.parquet\"\n",
     "        ).resolve(strict=True),\n",
     "        \"output\": pathlib.Path(\n",
-    "            f\"{root_dir}/5.EDA/results/sc_fs_umap.parquet\"\n",
+    "            f\"{output_base}/sc_fs_umap.parquet\"\n",
     "        ).resolve(),\n",
     "    },\n",
     "    \"sc_agg\": {\n",
     "        \"input\": pathlib.Path(\n",
-    "            f\"{profile_base_dir}/data/all_patient_profiles/sc_agg_profiles.parquet\"\n",
+    "            f\"{input_base}/sc_agg_profiles.parquet\"\n",
     "        ).resolve(strict=True),\n",
     "        \"output\": pathlib.Path(\n",
-    "            f\"{root_dir}/5.EDA/results/sc_agg_umap.parquet\"\n",
-    "        ).resolve(),\n",
-    "    },\n",
-    "    \"organoid\": {\n",
-    "        \"input\": pathlib.Path(\n",
-    "            f\"{profile_base_dir}/data/all_patient_profiles/organoid_profiles.parquet\"\n",
-    "        ).resolve(strict=True),\n",
-    "        \"output\": pathlib.Path(\n",
-    "            f\"{root_dir}/5.EDA/results/organoid_umap.parquet\"\n",
-    "        ).resolve(),\n",
-    "    },\n",
-    "    \"organoid_fs\": {\n",
-    "        \"input\": pathlib.Path(\n",
-    "            f\"{profile_base_dir}/data/all_patient_profiles/organoid_fs_profiles.parquet\"\n",
-    "        ).resolve(strict=True),\n",
-    "        \"output\": pathlib.Path(\n",
-    "            f\"{root_dir}/5.EDA/results/organoid_fs_umap.parquet\"\n",
-    "        ).resolve(),\n",
-    "    },\n",
-    "    \"organoid_agg\": {\n",
-    "        \"input\": pathlib.Path(\n",
-    "            f\"{profile_base_dir}/data/all_patient_profiles/organoid_agg_profiles.parquet\"\n",
-    "        ).resolve(strict=True),\n",
-    "        \"output\": pathlib.Path(\n",
-    "            f\"{root_dir}/5.EDA/results/organoid_agg_umap.parquet\"\n",
+    "            f\"{output_base}/sc_agg_umap.parquet\"\n",
     "        ).resolve(),\n",
     "    },\n",
     "    \"sc_consensus\": {\n",
     "        \"input\": pathlib.Path(\n",
-    "            f\"{profile_base_dir}/data/all_patient_profiles/sc_consensus_profiles.parquet\"\n",
+    "            f\"{input_base}/sc_consensus_profiles.parquet\"\n",
     "        ).resolve(strict=True),\n",
     "        \"output\": pathlib.Path(\n",
-    "            f\"{root_dir}/5.EDA/results/sc_consensus_umap.parquet\"\n",
-    "        ).resolve(),\n",
-    "    },\n",
-    "    \"organoid_consensus\": {\n",
-    "        \"input\": pathlib.Path(\n",
-    "            f\"{profile_base_dir}/data/all_patient_profiles/organoid_consensus_profiles.parquet\"\n",
-    "        ).resolve(strict=True),\n",
-    "        \"output\": pathlib.Path(\n",
-    "            f\"{root_dir}/5.EDA/results/organoid_consensus_umap.parquet\"\n",
+    "            f\"{output_base}/sc_consensus_umap.parquet\"\n",
     "        ).resolve(),\n",
     "    },\n",
     "}\n",
     "\n",
-    "data_dict[\"organoid\"][\"output\"].parent.mkdir(parents=True, exist_ok=True)"
+    "# Create output directory\n",
+    "data_dict[\"sc\"][\"output\"].parent.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "if DIMENSION == \"2D\":\n",
+    "    print(f\"Using projection method: {PROJECTION_METHOD}\")\n",
+    "print(f\"Output directory: {data_dict['sc']['output'].parent}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 18,
    "id": "193b8914",
    "metadata": {},
    "outputs": [
@@ -119,32 +118,32 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(11623, 1931)\n",
-      "Data shape after dropping NaN values: (11623, 1931)\n"
+      "(11820, 2892)\n",
+      "Data shape after dropping NaN values: (11166, 2892)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/lippincm/miniforge3/envs/GFF_analysis/lib/python3.12/site-packages/sklearn/utils/deprecation.py:132: FutureWarning: 'force_all_finite' was renamed to 'ensure_all_finite' in 1.6 and will be removed in 1.8.\n",
-      "  warnings.warn(\n"
+      "/Users/kaylorhuang/miniforge3/envs/GFF_analysis/lib/python3.12/site-packages/umap/umap_.py:1952: UserWarning: n_jobs value 1 overridden to 1 by setting random_state. Use no seed for parallelism.\n",
+      "  warn(\n"
      ]
     },
     {
-     "ename": "ValueError",
-     "evalue": "Input contains NaN.",
+     "ename": "KeyboardInterrupt",
+     "evalue": "",
      "output_type": "error",
      "traceback": [
       "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mValueError\u001b[39m                                Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[3]\u001b[39m\u001b[32m, line 18\u001b[39m\n\u001b[32m     15\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mData shape after dropping NaN values: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mfeatures_df.shape\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n\u001b[32m     16\u001b[39m \u001b[38;5;66;03m# Extract features and apply UMAP\u001b[39;00m\n\u001b[32m---> \u001b[39m\u001b[32m18\u001b[39m umap_embedding = \u001b[43mumap_object\u001b[49m\u001b[43m.\u001b[49m\u001b[43mfit_transform\u001b[49m\u001b[43m(\u001b[49m\u001b[43mfeatures_df\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     20\u001b[39m \u001b[38;5;66;03m# Create a DataFrame with UMAP results\u001b[39;00m\n\u001b[32m     21\u001b[39m umap_df = pd.DataFrame(umap_embedding, columns=[\u001b[33m\"\u001b[39m\u001b[33mUMAP1\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mUMAP2\u001b[39m\u001b[33m\"\u001b[39m])\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/miniforge3/envs/GFF_analysis/lib/python3.12/site-packages/umap/umap_.py:2928\u001b[39m, in \u001b[36mUMAP.fit_transform\u001b[39m\u001b[34m(self, X, y, force_all_finite, **kwargs)\u001b[39m\n\u001b[32m   2890\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mfit_transform\u001b[39m(\u001b[38;5;28mself\u001b[39m, X, y=\u001b[38;5;28;01mNone\u001b[39;00m, force_all_finite=\u001b[38;5;28;01mTrue\u001b[39;00m, **kwargs):\n\u001b[32m   2891\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"Fit X into an embedded space and return that transformed\u001b[39;00m\n\u001b[32m   2892\u001b[39m \u001b[33;03m    output.\u001b[39;00m\n\u001b[32m   2893\u001b[39m \n\u001b[32m   (...)\u001b[39m\u001b[32m   2926\u001b[39m \u001b[33;03m        Local radii of data points in the embedding (log-transformed).\u001b[39;00m\n\u001b[32m   2927\u001b[39m \u001b[33;03m    \"\"\"\u001b[39;00m\n\u001b[32m-> \u001b[39m\u001b[32m2928\u001b[39m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mfit\u001b[49m\u001b[43m(\u001b[49m\u001b[43mX\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43my\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mforce_all_finite\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   2929\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m.transform_mode == \u001b[33m\"\u001b[39m\u001b[33membedding\u001b[39m\u001b[33m\"\u001b[39m:\n\u001b[32m   2930\u001b[39m         \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m.output_dens:\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/miniforge3/envs/GFF_analysis/lib/python3.12/site-packages/umap/umap_.py:2372\u001b[39m, in \u001b[36mUMAP.fit\u001b[39m\u001b[34m(self, X, y, force_all_finite, **kwargs)\u001b[39m\n\u001b[32m   2368\u001b[39m     X = check_array(\n\u001b[32m   2369\u001b[39m         X, dtype=np.uint8, order=\u001b[33m\"\u001b[39m\u001b[33mC\u001b[39m\u001b[33m\"\u001b[39m, force_all_finite=force_all_finite\n\u001b[32m   2370\u001b[39m     )\n\u001b[32m   2371\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m-> \u001b[39m\u001b[32m2372\u001b[39m     X = \u001b[43mcheck_array\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m   2373\u001b[39m \u001b[43m        \u001b[49m\u001b[43mX\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2374\u001b[39m \u001b[43m        \u001b[49m\u001b[43mdtype\u001b[49m\u001b[43m=\u001b[49m\u001b[43mnp\u001b[49m\u001b[43m.\u001b[49m\u001b[43mfloat32\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2375\u001b[39m \u001b[43m        \u001b[49m\u001b[43maccept_sparse\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mcsr\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m   2376\u001b[39m \u001b[43m        \u001b[49m\u001b[43morder\u001b[49m\u001b[43m=\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mC\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m   2377\u001b[39m \u001b[43m        \u001b[49m\u001b[43mforce_all_finite\u001b[49m\u001b[43m=\u001b[49m\u001b[43mforce_all_finite\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2378\u001b[39m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   2379\u001b[39m \u001b[38;5;28mself\u001b[39m._raw_data = X\n\u001b[32m   2381\u001b[39m \u001b[38;5;66;03m# Handle all the optional arguments, setting default\u001b[39;00m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/miniforge3/envs/GFF_analysis/lib/python3.12/site-packages/sklearn/utils/validation.py:1105\u001b[39m, in \u001b[36mcheck_array\u001b[39m\u001b[34m(array, accept_sparse, accept_large_sparse, dtype, order, copy, force_writeable, force_all_finite, ensure_all_finite, ensure_non_negative, ensure_2d, allow_nd, ensure_min_samples, ensure_min_features, estimator, input_name)\u001b[39m\n\u001b[32m   1099\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\n\u001b[32m   1100\u001b[39m         \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mFound array with dim \u001b[39m\u001b[38;5;132;01m{\u001b[39;00marray.ndim\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m,\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m   1101\u001b[39m         \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33m while dim <= 2 is required\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mcontext\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m   1102\u001b[39m     )\n\u001b[32m   1104\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m ensure_all_finite:\n\u001b[32m-> \u001b[39m\u001b[32m1105\u001b[39m     \u001b[43m_assert_all_finite\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m   1106\u001b[39m \u001b[43m        \u001b[49m\u001b[43marray\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1107\u001b[39m \u001b[43m        \u001b[49m\u001b[43minput_name\u001b[49m\u001b[43m=\u001b[49m\u001b[43minput_name\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1108\u001b[39m \u001b[43m        \u001b[49m\u001b[43mestimator_name\u001b[49m\u001b[43m=\u001b[49m\u001b[43mestimator_name\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1109\u001b[39m \u001b[43m        \u001b[49m\u001b[43mallow_nan\u001b[49m\u001b[43m=\u001b[49m\u001b[43mensure_all_finite\u001b[49m\u001b[43m \u001b[49m\u001b[43m==\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mallow-nan\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[32m   1110\u001b[39m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1112\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m copy:\n\u001b[32m   1113\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m _is_numpy_namespace(xp):\n\u001b[32m   1114\u001b[39m         \u001b[38;5;66;03m# only make a copy if `array` and `array_orig` may share memory`\u001b[39;00m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/miniforge3/envs/GFF_analysis/lib/python3.12/site-packages/sklearn/utils/validation.py:120\u001b[39m, in \u001b[36m_assert_all_finite\u001b[39m\u001b[34m(X, allow_nan, msg_dtype, estimator_name, input_name)\u001b[39m\n\u001b[32m    117\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m first_pass_isfinite:\n\u001b[32m    118\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m120\u001b[39m \u001b[43m_assert_all_finite_element_wise\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m    121\u001b[39m \u001b[43m    \u001b[49m\u001b[43mX\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    122\u001b[39m \u001b[43m    \u001b[49m\u001b[43mxp\u001b[49m\u001b[43m=\u001b[49m\u001b[43mxp\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    123\u001b[39m \u001b[43m    \u001b[49m\u001b[43mallow_nan\u001b[49m\u001b[43m=\u001b[49m\u001b[43mallow_nan\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    124\u001b[39m \u001b[43m    \u001b[49m\u001b[43mmsg_dtype\u001b[49m\u001b[43m=\u001b[49m\u001b[43mmsg_dtype\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    125\u001b[39m \u001b[43m    \u001b[49m\u001b[43mestimator_name\u001b[49m\u001b[43m=\u001b[49m\u001b[43mestimator_name\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    126\u001b[39m \u001b[43m    \u001b[49m\u001b[43minput_name\u001b[49m\u001b[43m=\u001b[49m\u001b[43minput_name\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    127\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/miniforge3/envs/GFF_analysis/lib/python3.12/site-packages/sklearn/utils/validation.py:169\u001b[39m, in \u001b[36m_assert_all_finite_element_wise\u001b[39m\u001b[34m(X, xp, allow_nan, msg_dtype, estimator_name, input_name)\u001b[39m\n\u001b[32m    152\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m estimator_name \u001b[38;5;129;01mand\u001b[39;00m input_name == \u001b[33m\"\u001b[39m\u001b[33mX\u001b[39m\u001b[33m\"\u001b[39m \u001b[38;5;129;01mand\u001b[39;00m has_nan_error:\n\u001b[32m    153\u001b[39m     \u001b[38;5;66;03m# Improve the error message on how to handle missing values in\u001b[39;00m\n\u001b[32m    154\u001b[39m     \u001b[38;5;66;03m# scikit-learn.\u001b[39;00m\n\u001b[32m    155\u001b[39m     msg_err += (\n\u001b[32m    156\u001b[39m         \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m{\u001b[39;00mestimator_name\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m does not accept missing values\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    157\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33m encoded as NaN natively. For supervised learning, you might want\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m   (...)\u001b[39m\u001b[32m    167\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33m#estimators-that-handle-nan-values\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    168\u001b[39m     )\n\u001b[32m--> \u001b[39m\u001b[32m169\u001b[39m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(msg_err)\n",
-      "\u001b[31mValueError\u001b[39m: Input contains NaN."
+      "\u001b[31mKeyboardInterrupt\u001b[39m                         Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[18]\u001b[39m\u001b[32m, line 18\u001b[39m\n\u001b[32m     15\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mData shape after dropping NaN values: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mfeatures_df.shape\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m)\n\u001b[32m     16\u001b[39m \u001b[38;5;66;03m# Extract features and apply UMAP\u001b[39;00m\n\u001b[32m---> \u001b[39m\u001b[32m18\u001b[39m umap_embedding = \u001b[43mumap_object\u001b[49m\u001b[43m.\u001b[49m\u001b[43mfit_transform\u001b[49m\u001b[43m(\u001b[49m\u001b[43mfeatures_df\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m     20\u001b[39m \u001b[38;5;66;03m# Create a DataFrame with UMAP results\u001b[39;00m\n\u001b[32m     21\u001b[39m umap_df = pd.DataFrame(umap_embedding, columns=[\u001b[33m\"\u001b[39m\u001b[33mUMAP1\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mUMAP2\u001b[39m\u001b[33m\"\u001b[39m])\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/miniforge3/envs/GFF_analysis/lib/python3.12/site-packages/umap/umap_.py:2935\u001b[39m, in \u001b[36mUMAP.fit_transform\u001b[39m\u001b[34m(self, X, y, ensure_all_finite, **kwargs)\u001b[39m\n\u001b[32m   2897\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mfit_transform\u001b[39m(\u001b[38;5;28mself\u001b[39m, X, y=\u001b[38;5;28;01mNone\u001b[39;00m, ensure_all_finite=\u001b[38;5;28;01mTrue\u001b[39;00m, **kwargs):\n\u001b[32m   2898\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"Fit X into an embedded space and return that transformed\u001b[39;00m\n\u001b[32m   2899\u001b[39m \u001b[33;03m    output.\u001b[39;00m\n\u001b[32m   2900\u001b[39m \n\u001b[32m   (...)\u001b[39m\u001b[32m   2933\u001b[39m \u001b[33;03m        Local radii of data points in the embedding (log-transformed).\u001b[39;00m\n\u001b[32m   2934\u001b[39m \u001b[33;03m    \"\"\"\u001b[39;00m\n\u001b[32m-> \u001b[39m\u001b[32m2935\u001b[39m     \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mfit\u001b[49m\u001b[43m(\u001b[49m\u001b[43mX\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43my\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mensure_all_finite\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   2936\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m.transform_mode == \u001b[33m\"\u001b[39m\u001b[33membedding\u001b[39m\u001b[33m\"\u001b[39m:\n\u001b[32m   2937\u001b[39m         \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m.output_dens:\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/miniforge3/envs/GFF_analysis/lib/python3.12/site-packages/umap/umap_.py:2817\u001b[39m, in \u001b[36mUMAP.fit\u001b[39m\u001b[34m(self, X, y, ensure_all_finite, **kwargs)\u001b[39m\n\u001b[32m   2813\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m.transform_mode == \u001b[33m\"\u001b[39m\u001b[33membedding\u001b[39m\u001b[33m\"\u001b[39m:\n\u001b[32m   2814\u001b[39m     epochs = (\n\u001b[32m   2815\u001b[39m         \u001b[38;5;28mself\u001b[39m.n_epochs_list \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m.n_epochs_list \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;28;01melse\u001b[39;00m \u001b[38;5;28mself\u001b[39m.n_epochs\n\u001b[32m   2816\u001b[39m     )\n\u001b[32m-> \u001b[39m\u001b[32m2817\u001b[39m     \u001b[38;5;28mself\u001b[39m.embedding_, aux_data = \u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_fit_embed_data\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m   2818\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_raw_data\u001b[49m\u001b[43m[\u001b[49m\u001b[43mindex\u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2819\u001b[39m \u001b[43m        \u001b[49m\u001b[43mepochs\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2820\u001b[39m \u001b[43m        \u001b[49m\u001b[43minit\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2821\u001b[39m \u001b[43m        \u001b[49m\u001b[43mrandom_state\u001b[49m\u001b[43m,\u001b[49m\u001b[43m  \u001b[49m\u001b[38;5;66;43;03m# JH why raw data?\u001b[39;49;00m\n\u001b[32m   2822\u001b[39m \u001b[43m        \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2823\u001b[39m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   2825\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m.n_epochs_list \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[32m   2826\u001b[39m         \u001b[38;5;28;01mif\u001b[39;00m \u001b[33m\"\u001b[39m\u001b[33membedding_list\u001b[39m\u001b[33m\"\u001b[39m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m aux_data:\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/miniforge3/envs/GFF_analysis/lib/python3.12/site-packages/umap/umap_.py:2872\u001b[39m, in \u001b[36mUMAP._fit_embed_data\u001b[39m\u001b[34m(self, X, n_epochs, init, random_state, **kwargs)\u001b[39m\n\u001b[32m   2867\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34m_fit_embed_data\u001b[39m(\u001b[38;5;28mself\u001b[39m, X, n_epochs, init, random_state, **kwargs):\n\u001b[32m   2868\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"A method wrapper for simplicial_set_embedding that can be\u001b[39;00m\n\u001b[32m   2869\u001b[39m \u001b[33;03m    replaced by subclasses. Arbitrary keyword arguments can be passed\u001b[39;00m\n\u001b[32m   2870\u001b[39m \u001b[33;03m    through .fit() and .fit_transform().\u001b[39;00m\n\u001b[32m   2871\u001b[39m \u001b[33;03m    \"\"\"\u001b[39;00m\n\u001b[32m-> \u001b[39m\u001b[32m2872\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43msimplicial_set_embedding\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m   2873\u001b[39m \u001b[43m        \u001b[49m\u001b[43mX\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2874\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mgraph_\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2875\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mn_components\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2876\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_initial_alpha\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2877\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_a\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2878\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_b\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2879\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mrepulsion_strength\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2880\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mnegative_sample_rate\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2881\u001b[39m \u001b[43m        \u001b[49m\u001b[43mn_epochs\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2882\u001b[39m \u001b[43m        \u001b[49m\u001b[43minit\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2883\u001b[39m \u001b[43m        \u001b[49m\u001b[43mrandom_state\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2884\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_input_distance_func\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2885\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_metric_kwds\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2886\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mdensmap\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2887\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_densmap_kwds\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2888\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43moutput_dens\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2889\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_output_distance_func\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2890\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43m_output_metric_kwds\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2891\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43moutput_metric\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01min\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43meuclidean\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43ml2\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2892\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mrandom_state\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;129;43;01mis\u001b[39;49;00m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[32m   2893\u001b[39m \u001b[43m        \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mverbose\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2894\u001b[39m \u001b[43m        \u001b[49m\u001b[43mtqdm_kwds\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m.\u001b[49m\u001b[43mtqdm_kwds\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   2895\u001b[39m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/miniforge3/envs/GFF_analysis/lib/python3.12/site-packages/umap/umap_.py:1195\u001b[39m, in \u001b[36msimplicial_set_embedding\u001b[39m\u001b[34m(data, graph, n_components, initial_alpha, a, b, gamma, negative_sample_rate, n_epochs, init, random_state, metric, metric_kwds, densmap, densmap_kwds, output_dens, output_metric, output_metric_kwds, euclidean_output, parallel, verbose, tqdm_kwds)\u001b[39m\n\u001b[32m   1188\u001b[39m embedding = (\n\u001b[32m   1189\u001b[39m     \u001b[32m10.0\u001b[39m\n\u001b[32m   1190\u001b[39m     * (embedding - np.min(embedding, \u001b[32m0\u001b[39m))\n\u001b[32m   1191\u001b[39m     / (np.max(embedding, \u001b[32m0\u001b[39m) - np.min(embedding, \u001b[32m0\u001b[39m))\n\u001b[32m   1192\u001b[39m ).astype(np.float32, order=\u001b[33m\"\u001b[39m\u001b[33mC\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m   1194\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m euclidean_output:\n\u001b[32m-> \u001b[39m\u001b[32m1195\u001b[39m     embedding = \u001b[43moptimize_layout_euclidean\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m   1196\u001b[39m \u001b[43m        \u001b[49m\u001b[43membedding\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1197\u001b[39m \u001b[43m        \u001b[49m\u001b[43membedding\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1198\u001b[39m \u001b[43m        \u001b[49m\u001b[43mhead\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1199\u001b[39m \u001b[43m        \u001b[49m\u001b[43mtail\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1200\u001b[39m \u001b[43m        \u001b[49m\u001b[43mn_epochs\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1201\u001b[39m \u001b[43m        \u001b[49m\u001b[43mn_vertices\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1202\u001b[39m \u001b[43m        \u001b[49m\u001b[43mepochs_per_sample\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1203\u001b[39m \u001b[43m        \u001b[49m\u001b[43ma\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1204\u001b[39m \u001b[43m        \u001b[49m\u001b[43mb\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1205\u001b[39m \u001b[43m        \u001b[49m\u001b[43mrng_state\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1206\u001b[39m \u001b[43m        \u001b[49m\u001b[43mgamma\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1207\u001b[39m \u001b[43m        \u001b[49m\u001b[43minitial_alpha\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1208\u001b[39m \u001b[43m        \u001b[49m\u001b[43mnegative_sample_rate\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1209\u001b[39m \u001b[43m        \u001b[49m\u001b[43mparallel\u001b[49m\u001b[43m=\u001b[49m\u001b[43mparallel\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1210\u001b[39m \u001b[43m        \u001b[49m\u001b[43mverbose\u001b[49m\u001b[43m=\u001b[49m\u001b[43mverbose\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1211\u001b[39m \u001b[43m        \u001b[49m\u001b[43mdensmap\u001b[49m\u001b[43m=\u001b[49m\u001b[43mdensmap\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1212\u001b[39m \u001b[43m        \u001b[49m\u001b[43mdensmap_kwds\u001b[49m\u001b[43m=\u001b[49m\u001b[43mdensmap_kwds\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1213\u001b[39m \u001b[43m        \u001b[49m\u001b[43mtqdm_kwds\u001b[49m\u001b[43m=\u001b[49m\u001b[43mtqdm_kwds\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m   1214\u001b[39m \u001b[43m        \u001b[49m\u001b[43mmove_other\u001b[49m\u001b[43m=\u001b[49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[32m   1215\u001b[39m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m   1216\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m   1217\u001b[39m     embedding = optimize_layout_generic(\n\u001b[32m   1218\u001b[39m         embedding,\n\u001b[32m   1219\u001b[39m         embedding,\n\u001b[32m   (...)\u001b[39m\u001b[32m   1235\u001b[39m         move_other=\u001b[38;5;28;01mTrue\u001b[39;00m,\n\u001b[32m   1236\u001b[39m     )\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/miniforge3/envs/GFF_analysis/lib/python3.12/site-packages/umap/layouts.py:401\u001b[39m, in \u001b[36moptimize_layout_euclidean\u001b[39m\u001b[34m(head_embedding, tail_embedding, head, tail, n_epochs, n_vertices, epochs_per_sample, a, b, rng_state, gamma, initial_alpha, negative_sample_rate, parallel, verbose, densmap, densmap_kwds, tqdm_kwds, move_other)\u001b[39m\n\u001b[32m    398\u001b[39m     dens_re_mean = \u001b[32m0\u001b[39m\n\u001b[32m    399\u001b[39m     dens_re_cov = \u001b[32m0\u001b[39m\n\u001b[32m--> \u001b[39m\u001b[32m401\u001b[39m \u001b[43moptimize_fn\u001b[49m\u001b[43m(\u001b[49m\n\u001b[32m    402\u001b[39m \u001b[43m    \u001b[49m\u001b[43mhead_embedding\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    403\u001b[39m \u001b[43m    \u001b[49m\u001b[43mtail_embedding\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    404\u001b[39m \u001b[43m    \u001b[49m\u001b[43mhead\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    405\u001b[39m \u001b[43m    \u001b[49m\u001b[43mtail\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    406\u001b[39m \u001b[43m    \u001b[49m\u001b[43mn_vertices\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    407\u001b[39m \u001b[43m    \u001b[49m\u001b[43mepochs_per_sample\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    408\u001b[39m \u001b[43m    \u001b[49m\u001b[43ma\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    409\u001b[39m \u001b[43m    \u001b[49m\u001b[43mb\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    410\u001b[39m \u001b[43m    \u001b[49m\u001b[43mrng_state_per_sample\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    411\u001b[39m \u001b[43m    \u001b[49m\u001b[43mgamma\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    412\u001b[39m \u001b[43m    \u001b[49m\u001b[43mdim\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    413\u001b[39m \u001b[43m    \u001b[49m\u001b[43mmove_other\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    414\u001b[39m \u001b[43m    \u001b[49m\u001b[43malpha\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    415\u001b[39m \u001b[43m    \u001b[49m\u001b[43mepochs_per_negative_sample\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    416\u001b[39m \u001b[43m    \u001b[49m\u001b[43mepoch_of_next_negative_sample\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    417\u001b[39m \u001b[43m    \u001b[49m\u001b[43mepoch_of_next_sample\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    418\u001b[39m \u001b[43m    \u001b[49m\u001b[43mn\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    419\u001b[39m \u001b[43m    \u001b[49m\u001b[43mdensmap_flag\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    420\u001b[39m \u001b[43m    \u001b[49m\u001b[43mdens_phi_sum\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    421\u001b[39m \u001b[43m    \u001b[49m\u001b[43mdens_re_sum\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    422\u001b[39m \u001b[43m    \u001b[49m\u001b[43mdens_re_cov\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    423\u001b[39m \u001b[43m    \u001b[49m\u001b[43mdens_re_std\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    424\u001b[39m \u001b[43m    \u001b[49m\u001b[43mdens_re_mean\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    425\u001b[39m \u001b[43m    \u001b[49m\u001b[43mdens_lambda\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    426\u001b[39m \u001b[43m    \u001b[49m\u001b[43mdens_R\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    427\u001b[39m \u001b[43m    \u001b[49m\u001b[43mdens_mu\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    428\u001b[39m \u001b[43m    \u001b[49m\u001b[43mdens_mu_tot\u001b[49m\u001b[43m,\u001b[49m\n\u001b[32m    429\u001b[39m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[32m    431\u001b[39m alpha = initial_alpha * (\u001b[32m1.0\u001b[39m - (\u001b[38;5;28mfloat\u001b[39m(n) / \u001b[38;5;28mfloat\u001b[39m(n_epochs)))\n\u001b[32m    433\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m verbose \u001b[38;5;129;01mand\u001b[39;00m n % \u001b[38;5;28mint\u001b[39m(n_epochs / \u001b[32m10\u001b[39m) == \u001b[32m0\u001b[39m:\n",
+      "\u001b[31mKeyboardInterrupt\u001b[39m: "
      ]
     }
    ],
@@ -162,7 +161,7 @@
     "    features_df = df.drop(columns=metadata_columns, errors=\"ignore\")\n",
     "    print(features_df.shape)\n",
     "    # remove NaN values\n",
-    "    # features_df = features_df.dropna(axis=0, how=\"any\")\n",
+    "    features_df = features_df.dropna(axis=0, how=\"any\")\n",
     "    print(f\"Data shape after dropping NaN values: {features_df.shape}\")\n",
     "    # Extract features and apply UMAP\n",
     "\n",
@@ -176,6 +175,14 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be9d1eb5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "id": "c181f22f",
    "metadata": {},
@@ -185,7 +192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "72faea7d",
    "metadata": {},
    "outputs": [],
@@ -331,7 +338,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Add DIMENSION and PROJECTION_METHOD configuration variables
- Support both max_intensity and middle_slice 2D projections, as well as for 3D
- Update paths: input from data/2D_all_patient_profiles/, output to 1.EDA/results/umap/2D/
- Focus on single-cell profiles only (sc, sc_fs, sc_agg, sc_consensus)